### PR TITLE
feat(core): add deepractice transport handler

### DIFF
--- a/.changeset/deepractice-transport.md
+++ b/.changeset/deepractice-transport.md
@@ -1,0 +1,11 @@
+---
+"@resourcexjs/core": minor
+"resourcexjs": minor
+---
+
+Add built-in Deepractice transport for ecosystem local storage:
+
+- Add `deepracticeHandler(config?)` factory function
+- Maps `deepractice://path` to `~/.deepractice/path`
+- Configurable `parentDir` for testing and custom installations
+- Full capabilities: read/write/list/delete/exists/stat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Transport handlers (`packages/core/src/transport/`) provide I/O primitives:
 
 - `https`, `http` - Read-only network access
 - `file` - Full filesystem access (read/write/list/delete)
+- `deepractice` - Deepractice local storage (~/.deepractice, configurable via factory function)
 
 Semantic handlers (`packages/core/src/semantic/`) orchestrate transport primitives:
 

--- a/README.md
+++ b/README.md
@@ -131,15 +131,37 @@ You can mix and match any semantic with any transport:
 
 **Transport:**
 
-| Name    | Capabilities           | Description      |
-| ------- | ---------------------- | ---------------- |
-| `https` | read                   | HTTPS protocol   |
-| `http`  | read                   | HTTP protocol    |
-| `file`  | read/write/list/delete | Local filesystem |
+| Name          | Capabilities           | Description                                |
+| ------------- | ---------------------- | ------------------------------------------ |
+| `https`       | read                   | HTTPS protocol                             |
+| `http`        | read                   | HTTP protocol                              |
+| `file`        | read/write/list/delete | Local filesystem                           |
+| `deepractice` | read/write/list/delete | Deepractice local storage (~/.deepractice) |
 
 ## Configuration and Custom
 
 ResourceX is fully configurable via the `createResourceX()` config object.
+
+### Deepractice Transport
+
+Built-in transport for Deepractice ecosystem, automatically maps to `~/.deepractice/`:
+
+```typescript
+import { createResourceX, deepracticeHandler } from "resourcexjs";
+
+const rx = createResourceX({
+  transports: [deepracticeHandler()],
+});
+
+// Automatically maps to ~/.deepractice/sandbox/logs/app.log
+await rx.deposit("arp:text:deepractice://sandbox/logs/app.log", "log entry");
+
+// Custom parent directory (for testing or custom installations)
+const rx = createResourceX({
+  transports: [deepracticeHandler({ parentDir: "/var/data" })],
+});
+// → /var/data/.deepractice/sandbox/logs/app.log
+```
 
 ### Custom Resources (URL Shortcuts)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,15 +131,37 @@ Semantic 和 Transport 可以任意组合：
 
 **Transport:**
 
-| 名称    | 能力            | 描述         |
-| ------- | --------------- | ------------ |
-| `https` | 读              | HTTPS 协议   |
-| `http`  | 读              | HTTP 协议    |
-| `file`  | 读/写/列表/删除 | 本地文件系统 |
+| 名称          | 能力            | 描述                                  |
+| ------------- | --------------- | ------------------------------------- |
+| `https`       | 读              | HTTPS 协议                            |
+| `http`        | 读              | HTTP 协议                             |
+| `file`        | 读/写/列表/删除 | 本地文件系统                          |
+| `deepractice` | 读/写/列表/删除 | Deepractice 本地存储 (~/.deepractice) |
 
 ## 配置和自定义
 
 ResourceX 通过 `createResourceX()` 配置对象进行完全配置。
+
+### Deepractice Transport
+
+Deepractice 生态内置 transport，自动映射到 `~/.deepractice/`：
+
+```typescript
+import { createResourceX, deepracticeHandler } from "resourcexjs";
+
+const rx = createResourceX({
+  transports: [deepracticeHandler()],
+});
+
+// 自动映射到 ~/.deepractice/sandbox/logs/app.log
+await rx.deposit("arp:text:deepractice://sandbox/logs/app.log", "日志内容");
+
+// 自定义父目录（用于测试或自定义安装）
+const rx = createResourceX({
+  transports: [deepracticeHandler({ parentDir: "/var/data" })],
+});
+// → /var/data/.deepractice/sandbox/logs/app.log
+```
 
 ### 自定义 Resource（URL 快捷方式）
 

--- a/bdd/features/deepractice-transport.feature
+++ b/bdd/features/deepractice-transport.feature
@@ -1,0 +1,58 @@
+@deepractice @transport
+Feature: Deepractice Transport
+  Built-in transport for Deepractice ecosystem local storage
+
+  @e2e
+  Scenario: Resolve from deepractice transport with default config
+    Given deepractice handler with default config
+    And local file at deepractice path "sandbox/test.txt" with content "test content"
+    When resolve "arp:text:deepractice://sandbox/test.txt"
+    Then should return resource object
+    And type should be "text"
+    And content should be "test content"
+
+  @e2e
+  Scenario: Deposit to deepractice transport with default config
+    Given deepractice handler with default config
+    When deposit "hello deepractice" to "arp:text:deepractice://sandbox/greeting.txt"
+    Then should succeed without error
+    And file at deepractice path "sandbox/greeting.txt" should contain "hello deepractice"
+
+  @e2e
+  Scenario: Resolve from deepractice with custom parentDir
+    Given deepractice handler with parentDir "./bdd/test-data/custom"
+    And local file at custom deepractice path "sandbox/test.txt" with content "custom content"
+    When resolve "arp:text:deepractice://sandbox/test.txt"
+    Then should return resource object
+    And content should be "custom content"
+
+  @e2e
+  Scenario: Deposit to deepractice with custom parentDir
+    Given deepractice handler with parentDir "./bdd/test-data/custom"
+    When deposit "custom data" to "arp:text:deepractice://sandbox/data.txt"
+    Then should succeed without error
+    And file at custom deepractice path "sandbox/data.txt" should contain "custom data"
+
+  @e2e
+  Scenario: Binary resource with deepractice transport
+    Given deepractice handler with default config
+    And binary content from bytes [0xDE, 0xAD, 0xBE, 0xEF]
+    When deposit the content to "arp:binary:deepractice://blobs/data.bin"
+    And resolve "arp:binary:deepractice://blobs/data.bin"
+    Then should return resource object
+    And type should be "binary"
+    And content bytes should be [0xDE, 0xAD, 0xBE, 0xEF]
+
+  @e2e
+  Scenario: Check existence with deepractice transport
+    Given deepractice handler with default config
+    When deposit "exists test" to "arp:text:deepractice://test-exists.txt"
+    Then resource "arp:text:deepractice://test-exists.txt" should exist
+    And resource "arp:text:deepractice://not-exist.txt" should not exist
+
+  @e2e
+  Scenario: Delete with deepractice transport
+    Given deepractice handler with default config
+    When deposit "to delete" to "arp:text:deepractice://to-delete.txt"
+    And delete resource "arp:text:deepractice://to-delete.txt"
+    Then resource "arp:text:deepractice://to-delete.txt" should not exist

--- a/bdd/steps/common.steps.ts
+++ b/bdd/steps/common.steps.ts
@@ -1,13 +1,15 @@
 /**
  * Common step definitions shared across features
  */
-import { Given, Then } from "@cucumber/cucumber";
+import { Given, When, Then } from "@cucumber/cucumber";
 import { strict as assert } from "node:assert";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 interface CommonWorld {
+  rx?: import("resourcexjs").ResourceX;
   url?: string;
+  content?: unknown;
   result?: { type: string; content: unknown; meta?: Record<string, unknown> } | null;
   error?: Error | null;
 }
@@ -96,4 +98,36 @@ Then("meta.encoding should be {string}", function (this: CommonWorld, expected: 
   assert.ok(this.result, `Failed: ${this.error?.message}`);
   assert.ok(this.result.meta, "Result should have meta");
   assert.equal(this.result.meta.encoding, expected);
+});
+
+// Resource operations
+When("deposit the content to {string}", async function (this: CommonWorld, url: string) {
+  assert.ok(this.rx, "ResourceX not initialized");
+  assert.ok(this.content !== undefined && this.content !== null, "Content not set");
+  try {
+    await this.rx.deposit(url, this.content);
+  } catch (e) {
+    this.error = e as Error;
+  }
+});
+
+When("delete resource {string}", async function (this: CommonWorld, url: string) {
+  assert.ok(this.rx, "ResourceX not initialized");
+  try {
+    await this.rx.delete(url);
+  } catch (e) {
+    this.error = e as Error;
+  }
+});
+
+Then("resource {string} should exist", async function (this: CommonWorld, url: string) {
+  assert.ok(this.rx, "ResourceX not initialized");
+  const exists = await this.rx.exists(url);
+  assert.ok(exists, `Resource should exist: ${url}`);
+});
+
+Then("resource {string} should not exist", async function (this: CommonWorld, url: string) {
+  assert.ok(this.rx, "ResourceX not initialized");
+  const exists = await this.rx.exists(url);
+  assert.ok(!exists, `Resource should not exist: ${url}`);
 });

--- a/bdd/steps/deepractice.steps.ts
+++ b/bdd/steps/deepractice.steps.ts
@@ -1,0 +1,101 @@
+/**
+ * Deepractice transport step definitions
+ */
+import { Given, Then, Before, After } from "@cucumber/cucumber";
+import { strict as assert } from "node:assert";
+import { mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+interface DeepracticeWorld {
+  rx: import("resourcexjs").ResourceX | null;
+  parentDir: string;
+  result: { type: string; content: unknown; meta?: Record<string, unknown> } | null;
+  error: Error | null;
+  content: unknown;
+}
+
+Before({ tags: "@deepractice" }, async function (this: DeepracticeWorld) {
+  this.rx = null;
+  this.parentDir = homedir();
+  this.result = null;
+  this.error = null;
+  this.content = null;
+});
+
+After({ tags: "@deepractice" }, async function (this: DeepracticeWorld) {
+  // Clean up test files in default location
+  try {
+    await rm(join(homedir(), ".deepractice"), { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+
+  // Clean up test files in custom location
+  try {
+    await rm(join(process.cwd(), "bdd/test-data"), { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+Given("deepractice handler with default config", async function (this: DeepracticeWorld) {
+  const { createResourceX, deepracticeHandler } = await import("resourcexjs");
+  this.parentDir = homedir();
+  this.rx = createResourceX({
+    transports: [deepracticeHandler()],
+  });
+});
+
+Given(
+  "deepractice handler with parentDir {string}",
+  async function (this: DeepracticeWorld, parentDir: string) {
+    const { createResourceX, deepracticeHandler } = await import("resourcexjs");
+    // Adjust relative paths for BDD test directory
+    const adjustedParentDir = parentDir.startsWith("./")
+      ? join(process.cwd(), "bdd", parentDir.slice(2))
+      : parentDir;
+    this.parentDir = adjustedParentDir;
+    this.rx = createResourceX({
+      transports: [deepracticeHandler({ parentDir: adjustedParentDir })],
+    });
+  }
+);
+
+// Create local file at deepractice path (default location)
+Given(
+  "local file at deepractice path {string} with content {string}",
+  async function (this: DeepracticeWorld, path: string, content: string) {
+    const fullPath = join(this.parentDir, ".deepractice", path);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, content, "utf-8");
+  }
+);
+
+// Create local file at custom deepractice path
+Given(
+  "local file at custom deepractice path {string} with content {string}",
+  async function (this: DeepracticeWorld, path: string, content: string) {
+    const fullPath = join(this.parentDir, ".deepractice", path);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, content, "utf-8");
+  }
+);
+
+Then(
+  "file at deepractice path {string} should contain {string}",
+  async function (this: DeepracticeWorld, path: string, expected: string) {
+    const fullPath = join(this.parentDir, ".deepractice", path);
+    const content = await readFile(fullPath, "utf-8");
+    assert.ok(content.includes(expected), `File should contain "${expected}", got: ${content}`);
+  }
+);
+
+Then(
+  "file at custom deepractice path {string} should contain {string}",
+  async function (this: DeepracticeWorld, path: string, expected: string) {
+    const fullPath = join(this.parentDir, ".deepractice", path);
+    const content = await readFile(fullPath, "utf-8");
+    assert.ok(content.includes(expected), `File should contain "${expected}", got: ${content}`);
+  }
+);

--- a/issues/003-deepractice-transport.md
+++ b/issues/003-deepractice-transport.md
@@ -160,6 +160,18 @@ await rx.deposit("arp:json:deepractice://toolx/config.json", toolConfig);
 
 ---
 
-**Status**: Open
+**Status**: Completed
 **Priority**: High
 **Labels**: enhancement, transport-handler, ecosystem
+
+## 实现说明
+
+已实现为工厂函数模式：
+
+```typescript
+deepracticeHandler(config?: { parentDir?: string })
+```
+
+- 默认映射到 `~/.deepractice/`
+- 支持自定义 `parentDir`（测试时可用 `/tmp` 等）
+- `.deepractice` 目录名固定，保持生态一致性

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -141,6 +141,7 @@ registerSemanticHandler(jsonHandler);
 - `httpsHandler` - HTTPS protocol (read-only)
 - `httpHandler` - HTTP protocol (read-only)
 - `fileHandler` - Local file system (read/write/list/delete)
+- `deepracticeHandler(config?)` - Deepractice local storage (factory function, configurable parent directory)
 
 **Semantic:**
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,11 +17,13 @@ export {
   type TransportHandler,
   type TransportCapabilities,
   type ResourceStat,
+  type DeepracticeConfig,
   getTransportHandler,
   registerTransportHandler,
   httpsHandler,
   httpHandler,
   fileHandler,
+  deepracticeHandler,
 } from "./transport/index.js";
 
 // Semantic

--- a/packages/core/src/transport/deepractice.ts
+++ b/packages/core/src/transport/deepractice.ts
@@ -1,0 +1,142 @@
+/**
+ * Deepractice Transport Handler
+ * Maps deepractice:// to ~/.deepractice/ directory
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readFile, writeFile, readdir, access, unlink, mkdir, stat, rm } from "node:fs/promises";
+import { TransportError } from "../errors.js";
+import type { TransportHandler, ResourceStat } from "./types.js";
+
+export interface DeepracticeConfig {
+  /**
+   * Parent directory for .deepractice folder
+   * @default homedir()
+   */
+  parentDir?: string;
+}
+
+/**
+ * Create deepractice transport handler
+ * Maps deepractice://path to parentDir/.deepractice/path
+ *
+ * @example
+ * ```typescript
+ * const handler = deepracticeHandler();
+ * // → ~/.deepractice/
+ *
+ * const handler = deepracticeHandler({ parentDir: "/var/data" });
+ * // → /var/data/.deepractice/
+ * ```
+ */
+export function deepracticeHandler(config: DeepracticeConfig = {}): TransportHandler {
+  const parentDir = config.parentDir || homedir();
+  const baseDir = join(parentDir, ".deepractice");
+
+  /**
+   * Resolve deepractice:// location to full filesystem path
+   */
+  function resolvePath(location: string): string {
+    return join(baseDir, location);
+  }
+
+  return {
+    name: "deepractice",
+
+    capabilities: {
+      canRead: true,
+      canWrite: true,
+      canList: true,
+      canDelete: true,
+      canStat: true,
+    },
+
+    async read(location: string): Promise<Buffer> {
+      const fullPath = resolvePath(location);
+      try {
+        return await readFile(fullPath);
+      } catch (error) {
+        throw new TransportError(
+          `Failed to read from deepractice: ${(error as Error).message}`,
+          "deepractice",
+          { cause: error }
+        );
+      }
+    },
+
+    async write(location: string, content: Buffer): Promise<void> {
+      const fullPath = resolvePath(location);
+      try {
+        // Ensure parent directory exists
+        await mkdir(join(fullPath, ".."), { recursive: true });
+        await writeFile(fullPath, content);
+      } catch (error) {
+        throw new TransportError(
+          `Failed to write to deepractice: ${(error as Error).message}`,
+          "deepractice",
+          { cause: error }
+        );
+      }
+    },
+
+    async list(location: string): Promise<string[]> {
+      const fullPath = resolvePath(location);
+      try {
+        return await readdir(fullPath);
+      } catch (error) {
+        throw new TransportError(
+          `Failed to list deepractice directory: ${(error as Error).message}`,
+          "deepractice",
+          { cause: error }
+        );
+      }
+    },
+
+    async exists(location: string): Promise<boolean> {
+      const fullPath = resolvePath(location);
+      try {
+        await access(fullPath);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async stat(location: string): Promise<ResourceStat> {
+      const fullPath = resolvePath(location);
+      try {
+        const stats = await stat(fullPath);
+        return {
+          size: stats.size,
+          isDirectory: stats.isDirectory(),
+          modifiedAt: stats.mtime,
+        };
+      } catch (error) {
+        throw new TransportError(
+          `Failed to stat deepractice resource: ${(error as Error).message}`,
+          "deepractice",
+          { cause: error }
+        );
+      }
+    },
+
+    async delete(location: string): Promise<void> {
+      const fullPath = resolvePath(location);
+      try {
+        const stats = await stat(fullPath);
+        if (stats.isDirectory()) {
+          await rm(fullPath, { recursive: true, force: true });
+        } else {
+          await unlink(fullPath);
+        }
+      } catch (error) {
+        throw new TransportError(
+          `Failed to delete from deepractice: ${(error as Error).message}`,
+          "deepractice",
+          { cause: error }
+        );
+      }
+    },
+  };
+}

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -7,6 +7,7 @@ import { TransportError } from "../errors.js";
 export type { TransportHandler, TransportCapabilities, ResourceStat } from "./types.js";
 export { HttpTransportHandler, httpsHandler, httpHandler } from "./http.js";
 export { FileTransportHandler, fileHandler } from "./file.js";
+export { deepracticeHandler, type DeepracticeConfig } from "./deepractice.js";
 
 import type { TransportHandler } from "./types.js";
 import { httpsHandler, httpHandler } from "./http.js";

--- a/packages/resourcex/src/index.ts
+++ b/packages/resourcex/src/index.ts
@@ -34,6 +34,10 @@ export type {
   SemanticHandler,
   TextResource,
   ResourceDefinition,
+  DeepracticeConfig,
 } from "@resourcexjs/core";
+
+// Re-export built-in handlers
+export { deepracticeHandler } from "@resourcexjs/core";
 
 export { ResourceXError, ParseError, TransportError, SemanticError } from "@resourcexjs/core";


### PR DESCRIPTION
## Summary

- Add built-in `deepracticeHandler()` for Deepractice ecosystem
- Maps `deepractice://path` to `~/.deepractice/path` 
- Factory function pattern with configurable `parentDir`
- Full capabilities: read/write/list/delete/exists/stat

## Usage

```typescript
import { createResourceX, deepracticeHandler } from "resourcexjs";

// Default config (maps to ~/.deepractice/)
const rx = createResourceX({
  transports: [deepracticeHandler()],
});

await rx.deposit("arp:text:deepractice://sandbox/logs/app.log", "log entry");

// Custom parent directory
const rx = createResourceX({
  transports: [deepracticeHandler({ parentDir: "/var/data" })],
});
// → /var/data/.deepractice/sandbox/logs/app.log
```

## Test plan

- [x] BDD tests for default config
- [x] BDD tests for custom parentDir
- [x] Binary resource support
- [x] Exists/Delete operations
- [x] All existing tests pass (68 unit + 33 BDD scenarios)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)